### PR TITLE
print files and rules when non-zero

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,10 +10,19 @@ const sorted = data => Object.keys(data)
 
 module.exports = (results) => {
   const { files, rules } = formatter(results)
+  const files_non_zero = Object.values(files).find(x => x)
+  const rules_non_zero = Object.values(rules).find(x => x)
 
-  console.log('==== Files ====')
-  display(files)
+  if (files_non_zero) {
+    console.log('==== Files ====')
+    display(files)
+  }
 
-  console.log('\n\n==== Rules ====')
-  display(sorted(rules))
+  if (rules_non_zero) {
+    if (files_non_zero) {
+      console.log('\n\n')
+    }
+    console.log('==== Rules ====')
+    display(sorted(rules))
+  }
 }


### PR DESCRIPTION
Fixes issue #6 and makes the output look cleaner when there are no errors.
